### PR TITLE
Fix batch test loop formatting

### DIFF
--- a/tests/test_system_integration.py
+++ b/tests/test_system_integration.py
@@ -420,7 +420,8 @@ class SystemIntegrationTests(unittest.TestCase):
         
         # 複数ケースデータ作成
         test_cases = []
-        for i in range(5):            case_data = CaseData(
+        for i in range(5):
+            case_data = CaseData(
                 case_number=f"BATCH-TEST-{i+1:03d}",
                 person_info=PersonInfo(
                     name=f"テスト太郎{i+1}",


### PR DESCRIPTION
## Summary
- split `for` statement onto its own line in system integration tests
- indent the batch processing block consistently

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_683fa477e52c8324b7f2b75156f9271c