### PR TITLE
Add security key missing test

### DIFF
--- a/tests/unit/test_security_manager.py
+++ b/tests/unit/test_security_manager.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+
+from config.app_config import AppConfig
+from utils.security_manager import IntegratedSecurityManager
+from utils.error_handler import SecurityError
+
+
+def test_get_encryption_key_requires_env(tmp_path):
+    """get_encryption_key should raise SecurityError when env var is missing"""
+    # Backup current environment variable
+    original = os.environ.pop('COMPENSATION_SYSTEM_ENCRYPTION_KEY', None)
+    try:
+        config = AppConfig()
+        config.database_directory = str(tmp_path)
+        security_manager = IntegratedSecurityManager(config)
+        with pytest.raises(SecurityError):
+            security_manager.get_encryption_key()
+    finally:
+        if original is not None:
+            os.environ['COMPENSATION_SYSTEM_ENCRYPTION_KEY'] = original


### PR DESCRIPTION
## Summary
- add unit test verifying IntegratedSecurityManager raises SecurityError when encryption key env var is missing

## Testing
- `pytest tests/unit/test_security_manager.py::test_get_encryption_key_requires_env -q` *(fails: DID NOT RAISE <class 'utils.error_handler.SecurityError'>)*

------
https://chatgpt.com/codex/tasks/task_e_683fad35fc448324b2b18b5df8804709