### PR TITLE
Fix integration test indent and engine helpers

### DIFF
--- a/tests/test_system_integration.py
+++ b/tests/test_system_integration.py
@@ -420,7 +420,8 @@ class SystemIntegrationTests(unittest.TestCase):
         
         # 複数ケースデータ作成
         test_cases = []
-        for i in range(5):            case_data = CaseData(
+        for i in range(5):
+            case_data = CaseData(
                 case_number=f"BATCH-TEST-{i+1:03d}",
                 person_info=PersonInfo(
                     name=f"テスト太郎{i+1}",


### PR DESCRIPTION
## Summary
- repair indentation in `test_system_integration.py`
- implement several helper functions in `CompensationEngine`

## Testing
- `flake8 | head -n 20`
- `pytest -q tests/test_system_integration.py` *(fails: ModuleNotFoundError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_683fb5537ae08324900326f26ed174fd